### PR TITLE
Improvements

### DIFF
--- a/src/main/java/net/querz/worldpruner/Main.java
+++ b/src/main/java/net/querz/worldpruner/Main.java
@@ -8,7 +8,7 @@ import net.querz.worldpruner.prune.Pruner;
 import net.querz.worldpruner.ui.Window;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import org.apache.logging.log4j.ThreadContext;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
@@ -18,8 +18,13 @@ public class Main {
 
 	private static final Logger LOGGER = LogManager.getLogger(Main.class);
 
-	public static void main(String[] args) {
-		if (args.length == 0) {
+	public static void main(String[] args) throws InterruptedException {
+
+		if (args.length == 0 || args.length == 1 && args[0].equals("--debug") || args[0].equals("-d")) {
+			if (args.length == 1) {
+				logLevel = "DEBUG";
+			}
+			ThreadContext.put("dynamicLogLevel", getLogLevel());
 			Window.create();
 		} else {
 			PruneData data = PruneData.parseArgs(args);
@@ -36,6 +41,12 @@ public class Main {
 
 			LOGGER.info("Pruning took " + t);
 		}
+	}
+
+	private static String logLevel = "INFO";
+
+	public static String getLogLevel() {
+		return logLevel;
 	}
 
 	private static String version;

--- a/src/main/java/net/querz/worldpruner/prune/PruneData.java
+++ b/src/main/java/net/querz/worldpruner/prune/PruneData.java
@@ -4,6 +4,7 @@ import net.querz.worldpruner.selection.Selection;
 import org.apache.commons.cli.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -118,6 +119,10 @@ public record PruneData(
 				.longOpt("continue-on-error")
 				.desc("If execution should continue if an error occurs")
 				.build());
+		options.addOption(Option.builder("d")
+				.longOpt("debug")
+				.desc("Enables debug logging to the log file")
+				.build());
 
 		CommandLineParser parser = new DefaultParser();
 		try {
@@ -145,6 +150,11 @@ public record PruneData(
 				LOGGER.error("Could not find world at \"{}\"", worldDir.getAbsolutePath());
 				return null;
 			}
+
+			if (line.hasOption("debug")) {
+				ThreadContext.put("dynamicLogLevel", "DEBUG");
+			}
+
 			return new PruneData(world, inhabitedTime, radius, whitelist, line.hasOption("continue-on-error"));
 		} catch (ParseException | IllegalArgumentException e) {
 			LOGGER.error(e.getMessage());

--- a/src/main/java/net/querz/worldpruner/prune/PruneData.java
+++ b/src/main/java/net/querz/worldpruner/prune/PruneData.java
@@ -23,16 +23,17 @@ public record PruneData(
 		long inhabitedTime,
 		int radius,
 		Selection whitelist,
-		boolean continueOnError) {
+		boolean continueOnError,
+		boolean whitelistOnly) {
 
 	private static final Logger LOGGER = LogManager.getLogger(PruneData.class);
 
-	public PruneData(WorldDirectory dir, long inhabitedTime, int radius, Selection whitelist, boolean continueOnError) {
-		this(dir.region, dir.poi, dir.entities, inhabitedTime, radius, whitelist, continueOnError);
+	public PruneData(WorldDirectory dir, long inhabitedTime, int radius, Selection whitelist, boolean continueOnError, boolean whitelistOnly) {
+		this(dir.region, dir.poi, dir.entities, inhabitedTime, radius, whitelist, continueOnError, whitelistOnly);
 	}
 
-	public PruneData(WorldDirectory dir, long inhabitedTime, int radius, Selection whitelist) {
-		this(dir, inhabitedTime, radius, whitelist, false);
+	public PruneData(WorldDirectory dir, long inhabitedTime, int radius, Selection whitelist, boolean whitelistOnly) {
+		this(dir, inhabitedTime, radius, whitelist, false, whitelistOnly);
 	}
 
 	public static final int MIN_RADIUS = 0;
@@ -114,6 +115,10 @@ public record PruneData(
 				.hasArg()
 				.desc("The path to whitelist CSV file")
 				.build());
+		options.addOption(Option.builder("l")
+				.longOpt("white-list-only")
+				.desc("Prune everything except the whitelist")
+				.build());
 
 		options.addOption(Option.builder("c")
 				.longOpt("continue-on-error")
@@ -155,7 +160,7 @@ public record PruneData(
 				ThreadContext.put("dynamicLogLevel", "DEBUG");
 			}
 
-			return new PruneData(world, inhabitedTime, radius, whitelist, line.hasOption("continue-on-error"));
+			return new PruneData(world, inhabitedTime, radius, whitelist, line.hasOption("c"), line.hasOption("l"));
 		} catch (ParseException | IllegalArgumentException e) {
 			LOGGER.error(e.getMessage());
 			printHelp(options);

--- a/src/main/java/net/querz/worldpruner/prune/Pruner.java
+++ b/src/main/java/net/querz/worldpruner/prune/Pruner.java
@@ -1,7 +1,6 @@
 package net.querz.worldpruner.prune;
 
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 import net.querz.mca.Chunk;
 import net.querz.mca.MCAFile;
 import net.querz.mca.MCAFileHandle;
@@ -10,13 +9,13 @@ import net.querz.mca.seekable.SeekableFile;
 import net.querz.nbt.CompoundTag;
 import net.querz.nbt.Tag;
 import net.querz.worldpruner.cli.Timer;
+import net.querz.worldpruner.selection.ChunkSet;
 import net.querz.worldpruner.selection.PrunerSelectionStreamTagVisitor;
 import net.querz.worldpruner.selection.Selection;
 import net.querz.worldpruner.prune.structures.StructureManager;
 import net.querz.worldpruner.selection.Point;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -97,34 +96,30 @@ public class Pruner {
 		return regions;
 	}
 
-	private int deFragment(File file, ShortOpenHashSet whitelist) throws IOException {
+	private DeFragmentResult deFragment(File file, ChunkSet whitelist) throws IOException {
 
 		// if the file only contains the header or the whitelist is empty we delete it
 		if (file.length() <= 8192 || whitelist != null && whitelist.isEmpty()) {
 			if (file.delete()) {
-				LOGGER.info("Deleted empty file {}", file);
+				LOGGER.info("Deleted empty file {} with size {}", file, file.length());
 			} else {
-				if (errorHandler.handle(LOGGER, "Failed to delete empty file {}", file)) {
-					return -1;
+				if (errorHandler.handle(LOGGER, "Failed to delete empty file {} with size {}", file, file.length())) {
+					return new DeFragmentResult(0, 0, true);
 				}
 			}
-			return 0;
+			return new DeFragmentResult(1024, 0, false);
 		}
 
 		File tempFile = File.createTempFile(file.getName(), null, null);
 
 		int globalOffset = 2; // chunk data starts at 8192 (after 2 sectors)
 		int skippedChunks = 0;
+		int deletedChunks = 0;
 
 		try (RandomAccessFile temp = new RandomAccessFile(tempFile, "rw");
 			 RandomAccessFile source = new RandomAccessFile(file, "r")) {
 
 			for (short i = 0; i < 1024; i++) {
-				if (whitelist != null && !whitelist.contains(i)) {
-					skippedChunks++;
-					continue;
-				}
-
 				// read chunk data from source
 				source.seek(i * 4);
 
@@ -135,6 +130,11 @@ public class Pruner {
 				int sectors = source.read();
 				if (offset == 0 || sectors <= 0) {
 					skippedChunks++;
+					continue;
+				}
+
+				if (whitelist != null && !whitelist.get(i)) {
+					deletedChunks++;
 					continue;
 				}
 
@@ -169,21 +169,24 @@ public class Pruner {
 		if (skippedChunks == 1024) {
 			if (tempFile.exists()) {
 				if (!tempFile.delete()) {
-					LOGGER.warn("Failed to delete temp file {}", tempFile);
+					LOGGER.warn("Failed to delete temp file {} with size {}", tempFile, tempFile.length());
 				}
 			}
 			if (file.delete()) {
-				LOGGER.info("Deleted {} because it is empty", file);
+				LOGGER.info("Deleted {} with size {} because it is empty", file, file.length());
 			} else {
-				if (errorHandler.handle(LOGGER, "Failed to delete {} when all chunks were pruned", file)) {
-					return -1;
+				if (errorHandler.handle(LOGGER, "Failed to delete {} with size {} when all chunks were pruned", file, file.length())) {
+					return new DeFragmentResult(skippedChunks, deletedChunks, true);
 				}
 			}
 		} else {
+			LOGGER.info("Overwriting {} with size {} with temp file {} with size {}", file, file.length(), tempFile, tempFile.length());
 			Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
 		}
-		return 1024 - skippedChunks;
+		return new DeFragmentResult(skippedChunks, deletedChunks, false);
 	}
+
+	record DeFragmentResult(int skippedChunks, int deletedChunks, boolean error) {}
 
 	private File toFile(File parent, Point p) {
 		return new File(parent, String.format("r.%d.%d.mca", p.x(), p.z()));
@@ -206,6 +209,12 @@ public class Pruner {
 			Timer t = new Timer();
 			Point region = new Point(f);
 			File regionFile = toFile(pruneData.regionDir(), region);
+
+			// if the file is empty or only its header exists, we skip it
+			if (regionFile.exists() && regionFile.length() <= 8192) {
+				LOGGER.info("Skipped empty mca file {} with size {}", regionFile, regionFile.length());
+				continue;
+			}
 
 			MCAFile mcaFile;
 			try {
@@ -244,23 +253,31 @@ public class Pruner {
 		}
 		selection.addAll(chunksToKeep);
 
+		LOGGER.info(selection.getStats());
+
 		// remove all chunks that need to be deleted
-		if (deFragmentDir(pruneData.regionDir(), allRegionFiles, progress)) {
+		DeFragmentResult result;
+		if ((result = deFragmentDir(pruneData.regionDir(), allRegionFiles, progress)).error()) {
 			return;
 		}
-		if (deFragmentDir(pruneData.poiDir(), allPoiFiles, progress)) {
+		LOGGER.info("DeFragmented files in {} with result {}", pruneData.regionDir(), result);
+
+		if ((result = deFragmentDir(pruneData.poiDir(), allPoiFiles, progress)).error()) {
 			return;
 		}
-		if (deFragmentDir(pruneData.entitiesDir(), allEntityFiles, progress)) {
+		LOGGER.info("DeFragmented files in {} with result {}", pruneData.poiDir(), result);
+
+		if ((result = deFragmentDir(pruneData.entitiesDir(), allEntityFiles, progress)).error()) {
 			return;
 		}
+		LOGGER.info("DeFragmented files in {} with result {}", pruneData.entitiesDir(), result);
 
 		progress.done();
 	}
 
-	private boolean deFragmentDir(File dir, LongOpenHashSet regions, Progress progress) {
+	private DeFragmentResult deFragmentDir(File dir, LongOpenHashSet regions, Progress progress) {
 		if (dir == null) {
-			return false;
+			return new DeFragmentResult(0, 0, false);
 		}
 
 		progress.setMinimum(0);
@@ -269,8 +286,12 @@ public class Pruner {
 		progress.setIndeterminate(false);
 		progress.setMessage("DeFragmenting files in " + dir.getName());
 
+		int skippedChunks = 0;
+		int deletedChunks = 0;
+
 		for (long f : regions) {
 			if (selection.isRegionSelected(f)) {
+				skippedChunks += 1024;
 				progress.increment(1);
 				continue;
 			}
@@ -279,28 +300,31 @@ public class Pruner {
 			File regionFile = toFile(dir, region);
 
 			try {
-				ShortOpenHashSet selectedChunks = selection.getSelectedChunks(region);
+				ChunkSet selectedChunks = selection.getSelectedChunks(region);
 
 				Timer t = new Timer();
-				int pruned = deFragment(regionFile, selectedChunks);
-				if (pruned == -1) {
+				DeFragmentResult result = deFragment(regionFile, selectedChunks);
+				skippedChunks += result.skippedChunks();
+				deletedChunks += result.deletedChunks();
+				if (result.error()) {
 					progress.done();
-					return true;
+					return new DeFragmentResult(skippedChunks, deletedChunks, true);
 				}
-				LOGGER.info("Took {} to prune {} chunks in {}", t, pruned, regionFile);
+				LOGGER.info("Took {} to prune chunks in {} with result {}", t, regionFile, result);
 
 			} catch (IOException ex) {
-				if (errorHandler.handle(LOGGER, ex, "Failed to defragment mca file {}", regionFile)) {
+				if (errorHandler.handle(LOGGER, ex, "Failed to deFragment mca file {}", regionFile)) {
 					progress.done();
-					return true;
+					return new DeFragmentResult(skippedChunks, deletedChunks, true);
 				}
 			}
 			progress.increment(1);
 		}
-		return false;
+		return new DeFragmentResult(skippedChunks, deletedChunks, false);
 	}
 
-	private void applyRadius(Point chunk) {
+	private int applyRadius(Point chunk) {
+		int numSelected = 0;
 		Point min = chunk.sub(pruneData.radius());
 		Point max = chunk.add(pruneData.radius());
 		for (int x = min.x(); x <= max.x(); x++) {
@@ -309,9 +333,13 @@ public class Pruner {
 				int v = z - chunk.z();
 				double distSquared = h * h + v * v;
 				if (distSquared <= radiusSquared) {
-					selection.addChunk(new Point(x, z));
+					if (!selection.isChunkSelected(x, z)) {
+						selection.addChunk(new Point(x, z));
+						numSelected++;
+					}
 				}
 			}
 		}
+		return numSelected;
 	}
 }

--- a/src/main/java/net/querz/worldpruner/prune/Pruner.java
+++ b/src/main/java/net/querz/worldpruner/prune/Pruner.java
@@ -323,8 +323,7 @@ public class Pruner {
 		return new DeFragmentResult(skippedChunks, deletedChunks, false);
 	}
 
-	private int applyRadius(Point chunk) {
-		int numSelected = 0;
+	private void applyRadius(Point chunk) {
 		Point min = chunk.sub(pruneData.radius());
 		Point max = chunk.add(pruneData.radius());
 		for (int x = min.x(); x <= max.x(); x++) {
@@ -333,13 +332,9 @@ public class Pruner {
 				int v = z - chunk.z();
 				double distSquared = h * h + v * v;
 				if (distSquared <= radiusSquared) {
-					if (!selection.isChunkSelected(x, z)) {
-						selection.addChunk(new Point(x, z));
-						numSelected++;
-					}
+					selection.addChunk(new Point(x, z));
 				}
 			}
 		}
-		return numSelected;
 	}
 }

--- a/src/main/java/net/querz/worldpruner/selection/ChunkSet.java
+++ b/src/main/java/net/querz/worldpruner/selection/ChunkSet.java
@@ -1,0 +1,158 @@
+package net.querz.worldpruner.selection;
+
+import it.unimi.dsi.fastutil.shorts.ShortConsumer;
+import it.unimi.dsi.fastutil.shorts.ShortIterable;
+import it.unimi.dsi.fastutil.shorts.ShortIterator;
+import it.unimi.dsi.fastutil.shorts.ShortPredicate;
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+public class ChunkSet implements ShortIterable, Serializable, Cloneable {
+
+	long[] words = new long[16];
+	short setBits = 0;
+
+	public static final ChunkSet EMPTY_SET = new ChunkSet().immutable();
+
+	public void set(int index) {
+		if (!get(index)) {
+			setBits++;
+		}
+		words[index >> 6] |= (1L << index);
+	}
+
+	public void clear(int index) {
+		if (get(index)) {
+			setBits--;
+		}
+		words[index >> 6] &= ~(1L << index);
+	}
+
+	public void clear() {
+		for (int i = 0; i < 16; i++) {
+			words[i] = 0L;
+		}
+	}
+
+	public boolean get(int index) {
+		return (words[index >> 6] & (1L << index)) != 0;
+	}
+
+	public void merge(ChunkSet other) {
+		for (short i = 0; i < 1024; i++) {
+			if (other.get(i)) {
+				set(i);
+			}
+		}
+	}
+
+	@Override
+	public ChunkSet clone() {
+		ChunkSet clone;
+		try {
+			clone = (ChunkSet) super.clone();
+		} catch (CloneNotSupportedException ex) {
+			throw new RuntimeException(ex);
+		}
+		clone.words = words.clone();
+		clone.setBits = setBits;
+		return clone;
+	}
+
+	public short size() {
+		return setBits;
+	}
+
+	public boolean isEmpty() {
+		return setBits == 0;
+	}
+
+	@Override
+	@Nonnull
+	public ShortIterator iterator() {
+		return new ChunkIterator();
+	}
+
+	@Override
+	public void forEach(ShortConsumer action) {
+		for (short i = 0; i < 1024; i++) {
+			if (get(i)) {
+				action.accept(i);
+			}
+		}
+	}
+
+	public void removeIf(ShortPredicate predicate) {
+		for (short i = 0; i < 1024; i++) {
+			if (predicate.test(i)) {
+				clear(i);
+			}
+		}
+	}
+
+	private class ChunkIterator implements ShortIterator {
+
+		short index = 0;
+
+		@Override
+		public short nextShort() {
+			return (short) (index - 1);
+		}
+
+		@Override
+		public boolean hasNext() {
+			while (index < 1024) {
+				if (get(index++)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public void forEachRemaining(ShortConsumer action) {
+			for (; index < 1024; index++) {
+				if (get(index)) {
+					action.accept(index);
+				}
+			}
+		}
+	}
+
+	public ChunkSet immutable() {
+		return new ImmutableChunkSet(this);
+	}
+
+	private static class ImmutableChunkSet extends ChunkSet {
+
+		ImmutableChunkSet(ChunkSet chunkSet) {
+			words = chunkSet.words.clone();
+			setBits = chunkSet.setBits;
+		}
+
+		@Override
+		public void set(int index) {
+			throw new UnsupportedOperationException("cannot modify immutable ChunkSet");
+		}
+
+		@Override
+		public void clear(int index) {
+			throw new UnsupportedOperationException("cannot modify immutable ChunkSet");
+		}
+
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException("cannot modify immutable ChunkSet");
+		}
+
+		@Override
+		public void removeIf(ShortPredicate predicate) {
+			throw new UnsupportedOperationException("cannot modify immutable ChunkSet");
+		}
+
+		@Override
+		public void merge(ChunkSet other) {
+			throw new UnsupportedOperationException("cannot modify immutable ChunkSet");
+		}
+	}
+}

--- a/src/main/java/net/querz/worldpruner/selection/Point.java
+++ b/src/main/java/net/querz/worldpruner/selection/Point.java
@@ -10,8 +10,8 @@ public record Point(int x, int z) {
 		this((int) l, (int) (l >> 32));
 	}
 
-	public Point(short relativeChunk) {
-		this(relativeChunk, relativeChunk >> 5);
+	public Point(short chunkIndex) {
+		this(chunkIndex & 0x1F, chunkIndex >> 5);
 	}
 
 	public Point add(int x, int z) {
@@ -135,14 +135,14 @@ public record Point(int x, int z) {
 	}
 
 	// converts this absolute chunk coordinate into a relative chunk coordinate
-	public Point normalizeChunkInRegion() {
+	public Point asRelativeChunk() {
 		return new Point(x & 0x1F, z & 0x1F);
 	}
 
 	// returns a short containing relative chunk coordinates (0|0 to 31|31).
 	// only the first 1024 bits are populated which allows easy looping without having to convert.
-	public short getAsRelativeChunk() {
-		Point n = normalizeChunkInRegion();
+	public short asChunkIndex() {
+		Point n = asRelativeChunk();
 		return (short) (n.z << 5 | n.x & 0x1F);
 	}
 

--- a/src/main/java/net/querz/worldpruner/selection/Selection.java
+++ b/src/main/java/net/querz/worldpruner/selection/Selection.java
@@ -340,6 +340,10 @@ public class Selection {
 
 	@Override
 	public String toString() {
+		return getStats().toString();
+	}
+
+	public String toCSV() {
 		StringBuilder sb = new StringBuilder();
 		if (inverted) {
 			sb.append("inverted\n");

--- a/src/main/java/net/querz/worldpruner/selection/Selection.java
+++ b/src/main/java/net/querz/worldpruner/selection/Selection.java
@@ -3,12 +3,11 @@ package net.querz.worldpruner.selection;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 import java.io.*;
 
 public class Selection {
 
-	protected Long2ObjectOpenHashMap<ShortOpenHashSet> selection;
+	protected Long2ObjectOpenHashMap<ChunkSet> selection;
 	protected boolean inverted;
 
 	public Selection() {
@@ -16,13 +15,13 @@ public class Selection {
 		this.inverted = false;
 	}
 
-	protected Selection(Long2ObjectOpenHashMap<ShortOpenHashSet> selection, boolean inverted) {
+	protected Selection(Long2ObjectOpenHashMap<ChunkSet> selection, boolean inverted) {
 		this.selection = selection;
 		this.inverted = inverted;
 	}
 
 	public static Selection parseCSV(File csvFile) throws IOException {
-		Long2ObjectOpenHashMap<ShortOpenHashSet> sel = new Long2ObjectOpenHashMap<>();
+		Long2ObjectOpenHashMap<ChunkSet> sel = new Long2ObjectOpenHashMap<>();
 		Selection selection = new Selection(sel, false);
 		try (BufferedReader br = new BufferedReader(new FileReader(csvFile))) {
 			String line;
@@ -82,26 +81,26 @@ public class Selection {
 	public boolean isChunkSelected(int x, int z) {
 		Point pChunk = new Point(x, z);
 		Point pRegion = pChunk.chunkToRegion();
-		return isChunkSelected(pRegion.asLong(), pChunk.getAsRelativeChunk());
+		return isChunkSelected(pRegion.asLong(), pChunk.asChunkIndex());
 	}
 
 	protected boolean isChunkSelected(long region, short chunk) {
 		if (selection.containsKey(region)) {
-			ShortOpenHashSet chunks = selection.get(region);
-			return (chunks == null || chunks.contains(chunk)) != inverted;
+			ChunkSet chunks = selection.get(region);
+			return (chunks == null || chunks.get(chunk)) != inverted;
 		} else {
 			return inverted;
 		}
 	}
 
 	public void addChunk(Point chunk) {
-		addChunk(chunk.chunkToRegion().asLong(), chunk.getAsRelativeChunk());
+		addChunk(chunk.chunkToRegion().asLong(), chunk.asChunkIndex());
 	}
 
 
 	public void addChunk(long chunkCoords) {
 		Point chunk = new Point(chunkCoords);
-		addChunk(chunk.chunkToRegion().asLong(), chunk.getAsRelativeChunk());
+		addChunk(chunk.chunkToRegion().asLong(), chunk.asChunkIndex());
 	}
 
 	protected void addChunk(long region, short chunk) {
@@ -109,12 +108,12 @@ public class Selection {
 			return;
 		}
 		if (selection.containsKey(region)) {
-			ShortOpenHashSet chunks = selection.get(region);
+			ChunkSet chunks = selection.get(region);
 			if (chunks != null) {
 				if (inverted) {
-					chunks.remove(chunk);
+					chunks.clear(chunk);
 				} else {
-					chunks.add(chunk);
+					chunks.set(chunk);
 				}
 				if (chunks.size() == 1024) {
 					selection.put(region, null);
@@ -123,8 +122,8 @@ public class Selection {
 				}
 			}
 		} else {
-			ShortOpenHashSet chunks = new ShortOpenHashSet();
-			chunks.add(chunk);
+			ChunkSet chunks = new ChunkSet();
+			chunks.set(chunk);
 			selection.put(region, chunks);
 		}
 	}
@@ -145,29 +144,29 @@ public class Selection {
 		}
 	}
 
-	public ShortOpenHashSet getSelectedChunks(Point region) {
+	public ChunkSet getSelectedChunks(Point region) {
 		if (inverted) {
 			if (selection.containsKey(region.asLong())) {
-				return invertChunks(selection.get(region.asLong()));
+				return invertChunks(selection.get(region.asLong())).immutable();
 			} else {
 				return null;
 			}
 		}
 		if (selection.containsKey(region.asLong())) {
-			return selection.get(region.asLong());
+			return selection.get(region.asLong()).immutable();
 		} else {
-			return new ShortOpenHashSet(0);
+			return ChunkSet.EMPTY_SET;
 		}
 	}
 
-	private static ShortOpenHashSet invertChunks(ShortOpenHashSet chunks) {
+	private static ChunkSet invertChunks(ChunkSet chunks) {
 		if (chunks == null) {
-			return new ShortOpenHashSet(0);
+			return new ChunkSet();
 		}
-		ShortOpenHashSet result = new ShortOpenHashSet(1024 - chunks.size());
+		ChunkSet result = new ChunkSet();
 		for (short i = 0; i < 1024; i++) {
-			if (!chunks.contains(i)) {
-				result.add(i);
+			if (!chunks.get(i)) {
+				result.set(i);
 			}
 		}
 		return result;
@@ -176,7 +175,7 @@ public class Selection {
 	public void merge(Selection other) {
 		if (!inverted && !other.inverted) {
 
-			for (Long2ObjectMap.Entry<ShortOpenHashSet> entry : other.selection.long2ObjectEntrySet()) {
+			for (Long2ObjectMap.Entry<ChunkSet> entry : other.selection.long2ObjectEntrySet()) {
 				long r = entry.getLongKey();
 				if (selection.containsKey(r)) {
 					selection.put(r, add(selection.get(r), entry.getValue()));
@@ -186,10 +185,10 @@ public class Selection {
 			}
 		} else if (inverted && !other.inverted) {
 			// subtract all other chunks from this selection
-			for (Long2ObjectMap.Entry<ShortOpenHashSet> entry : other.selection.long2ObjectEntrySet()) {
+			for (Long2ObjectMap.Entry<ChunkSet> entry : other.selection.long2ObjectEntrySet()) {
 				long r = entry.getLongKey();
 				if (selection.containsKey(r)) {
-					ShortOpenHashSet result = subtract(selection.get(r), entry.getValue());
+					ChunkSet result = subtract(selection.get(r), entry.getValue());
 					if (result.size() == 0) {
 						selection.remove(r);
 					} else {
@@ -200,10 +199,10 @@ public class Selection {
 		} else if (!inverted) { // this selection is not inverted but the other is
 			// if something is marked in the other selection, we add it to this selection
 			// remember the regions we already touched and ignore them in the next loop
-			for (Long2ObjectMap.Entry<ShortOpenHashSet> entry : other.selection.long2ObjectEntrySet()) {
+			for (Long2ObjectMap.Entry<ChunkSet> entry : other.selection.long2ObjectEntrySet()) {
 				long r = entry.getLongKey();
 				if (selection.containsKey(r)) {
-					ShortOpenHashSet result;
+					ChunkSet result;
 					if ((result = subtract(cloneValue(entry.getValue()), selection.get(r))).size() == 0) {
 						selection.remove(r);
 					} else {
@@ -215,7 +214,7 @@ public class Selection {
 			}
 
 			// if something is marked in this selection, but not the other, we remove it so it's marked when inverted
-			for (Long2ObjectMap.Entry<ShortOpenHashSet> entry : selection.long2ObjectEntrySet()) {
+			for (Long2ObjectMap.Entry<ChunkSet> entry : selection.long2ObjectEntrySet()) {
 				long r = entry.getLongKey();
 				if (!other.selection.containsKey(r)) {
 					selection.remove(r);
@@ -225,7 +224,7 @@ public class Selection {
 			inverted = true;
 		} else { // both are inverted
 
-			for (Long2ObjectMap.Entry<ShortOpenHashSet> entry : selection.long2ObjectEntrySet()) {
+			for (Long2ObjectMap.Entry<ChunkSet> entry : selection.long2ObjectEntrySet()) {
 				long r = entry.getLongKey();
 				if (!other.selection.containsKey(r)) {
 					// region does not exist in other selection, so it is fully marked.
@@ -233,7 +232,7 @@ public class Selection {
 					selection.remove(r);
 				} else {
 					// region exists in other selection so we need to union them
-					ShortOpenHashSet union = union(entry.getValue(), other.selection.get(r));
+					ChunkSet union = union(entry.getValue(), other.selection.get(r));
 					// and put it in this selection
 					if (union != null && union.size() == 0) {
 						// the union is completely selected, so we remove this region to fully mark it
@@ -246,46 +245,46 @@ public class Selection {
 		}
 	}
 
-	private static ShortOpenHashSet cloneValue(ShortOpenHashSet v) {
+	private static ChunkSet cloneValue(ChunkSet v) {
 		return v == null ? null : v.clone();
 	}
 
-	private static ShortOpenHashSet union(ShortOpenHashSet a, ShortOpenHashSet b) {
+	private static ChunkSet union(ChunkSet a, ChunkSet b) {
 		if (a == null) {
 			return cloneValue(b);
 		}
 		if (b == null) {
 			return a;
 		}
-		for (short l : a) {
-			if (!b.contains(l)) {
-				a.remove(l);
+		a.forEach(l -> {
+			if (!b.get(l)) {
+				a.clear(l);
 			}
-		}
-		for (short l : b) {
-			if (!a.contains(l)) {
-				a.remove(l);
+		});
+		b.forEach(l -> {
+			if (!a.get(l)) {
+				a.clear(l);
 			}
-		}
+		});
 		return a;
 	}
 
-	private static ShortOpenHashSet subtract(ShortOpenHashSet source, ShortOpenHashSet target) {
+	private static ChunkSet subtract(ChunkSet source, ChunkSet target) {
 		if (source == null) {
 			return invertChunks(target);
 		}
 		if (target == null) {
-			return new ShortOpenHashSet(0);
+			return new ChunkSet();
 		}
-		source.removeIf(target::contains);
+		source.removeIf(target::get);
 		return source;
 	}
 
-	private static ShortOpenHashSet add(ShortOpenHashSet source, ShortOpenHashSet target) {
+	private static ChunkSet add(ChunkSet source, ChunkSet target) {
 		if (source == null || target == null) {
 			return null;
 		}
-		source.addAll(target);
+		source.merge(target);
 		return source.size() == 1024 ? null : source;
 	}
 
@@ -295,13 +294,57 @@ public class Selection {
 		}
 	}
 
+	public Stats getStats() {
+		int totalSelectedChunks = 0;
+		int totalChunksOfPartiallySelectedRegions = 0;
+		int partiallySelectedRegions = 0;
+		int fullySelectedRegions = 0;
+		int below64 = 0, below128 = 0, below256 = 0, below512 = 0;
+		for (Long2ObjectMap.Entry<ChunkSet> entry : selection.long2ObjectEntrySet()) {
+			if (entry.getValue() == null) {
+				totalSelectedChunks += 1024;
+				fullySelectedRegions++;
+			} else {
+				int size = entry.getValue().size();
+				totalSelectedChunks += size;
+				totalChunksOfPartiallySelectedRegions += size;
+				partiallySelectedRegions++;
+				if (size < 512) {
+					below512++;
+				}
+				if (size < 256) {
+					below256++;
+				}
+				if (size < 128) {
+					below128++;
+				}
+				if (size < 64) {
+					below64++;
+				}
+			}
+		}
+		return new Stats(
+			totalSelectedChunks,
+			totalChunksOfPartiallySelectedRegions,
+			partiallySelectedRegions,
+			fullySelectedRegions,
+			below64, below128, below256, below512);
+	}
+
+	public record Stats(
+		int totalSelectedChunks,
+		int totalChunksOfPartiallySelectedRegions,
+		int partiallySelectedRegions,
+		int fullySelectedRegions,
+		int below64, int below128, int below256, int below512) {}
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		if (inverted) {
 			sb.append("inverted\n");
 		}
-		for (Long2ObjectMap.Entry<ShortOpenHashSet> e : selection.long2ObjectEntrySet()) {
+		for (Long2ObjectMap.Entry<ChunkSet> e : selection.long2ObjectEntrySet()) {
 			Point region = new Point(e.getLongKey());
 			if (e.getValue() == null) {
 				sb.append(region.x()).append(';').append(region.z()).append('\n');

--- a/src/main/java/net/querz/worldpruner/ui/Window.java
+++ b/src/main/java/net/querz/worldpruner/ui/Window.java
@@ -74,8 +74,10 @@ public final class Window extends JFrame {
 
 		prune = new JButton("Prune");
 		prune.setAlignmentX(Component.CENTER_ALIGNMENT);
+		prune.setToolTipText("Prune everything below InhabitedTime with the given radius and except the whitelist");
 		pruneForWhitelist = new JButton("Prune for whitelist");
 		pruneForWhitelist.setAlignmentX(Component.CENTER_ALIGNMENT);
+		pruneForWhitelist.setToolTipText("Prune everything except the whitelist, ignoring InhabitedTime and radius");
 
 		JPanel options = new JPanel();
 		SpringLayout springLayout = new SpringLayout();
@@ -297,7 +299,10 @@ public final class Window extends JFrame {
 				}
 			} finally {
 				try {
-					SwingUtilities.invokeAndWait(() -> setFieldsEnabled(true));
+					SwingUtilities.invokeAndWait(() -> {
+						setFieldsEnabled(true);
+						pruneButtonValidator.run();
+					});
 				} catch (InterruptedException | InvocationTargetException ex) {
 					LOGGER.error("Failed to re-enable ui fields", ex);
 				}

--- a/src/main/java/net/querz/worldpruner/ui/Window.java
+++ b/src/main/java/net/querz/worldpruner/ui/Window.java
@@ -248,6 +248,22 @@ public final class Window extends JFrame {
 		INSTANCE.setVisible(true);
 	}
 
+	private static boolean confirmPrune() {
+		JEditorPane pane = new JEditorPane();
+		pane.setContentType("text/html");
+		pane.setText("""
+                <body style="font-family: Sans-Serif; font-size: 12;">
+                    <b>You are about to prune chunks from your world.</b>
+                    <br/>
+                    <b>This process can <i>NOT</i> be undone, make sure you backed up your world!</b>
+                </body>
+                """);
+		pane.setOpaque(false);
+		pane.setEditable(false);
+		int result = JOptionPane.showConfirmDialog(INSTANCE, pane, "Start pruning?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE);
+		return result == JOptionPane.OK_OPTION;
+	}
+
 	private static PruneData.WorldDirectory sanityCheck(JButton button) {
 		worldField.update();
 		whitelistField.update();
@@ -260,6 +276,10 @@ public final class Window extends JFrame {
 	}
 
 	private static void prune(PruneData.WorldDirectory worldDir, long duration, int radius, Selection selection, boolean whitelistOnly) {
+
+		if (!confirmPrune()) {
+			return;
+		}
 
 		setFieldsEnabled(false);
 

--- a/src/main/java/net/querz/worldpruner/ui/Window.java
+++ b/src/main/java/net/querz/worldpruner/ui/Window.java
@@ -6,7 +6,7 @@ import net.querz.worldpruner.prune.Pruner;
 import net.querz.worldpruner.selection.Selection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import org.apache.logging.log4j.ThreadContext;
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import java.awt.*;
@@ -191,6 +191,8 @@ public final class Window extends JFrame {
 		INSTANCE.pack();
 		INSTANCE.setLocationRelativeTo(null);
 		INSTANCE.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+		// make sure that the AWT Event Queue thread has this ThreadContext map
+		SwingUtilities.invokeLater(() -> ThreadContext.put("dynamicLogLevel", Main.getLogLevel()));
 		INSTANCE.setVisible(true);
 	}
 

--- a/src/main/java/net/querz/worldpruner/ui/Window.java
+++ b/src/main/java/net/querz/worldpruner/ui/Window.java
@@ -220,7 +220,7 @@ public final class Window extends JFrame {
 				selection = new Selection();
 			}
 
-			prune(worldDir, selection);
+			prune(worldDir, inhabitedTimeField.getDuration(), radiusField.getNumber(), selection, false);
 		});
 
 		pruneForWhitelist.addActionListener(e -> {
@@ -236,7 +236,7 @@ public final class Window extends JFrame {
 				return;
 			}
 
-			prune(worldDir, selection);
+			prune(worldDir, 0, 0, selection, true);
 		});
 
 		INSTANCE.getContentPane().add(panel);
@@ -259,18 +259,13 @@ public final class Window extends JFrame {
 		return worldDir;
 	}
 
-	private static void prune(PruneData.WorldDirectory worldDir, Selection selection) {
+	private static void prune(PruneData.WorldDirectory worldDir, long duration, int radius, Selection selection, boolean whitelistOnly) {
 
 		setFieldsEnabled(false);
 
 		new Thread(() -> {
 			try {
-				PruneData pruneData = new PruneData(
-						worldDir,
-						inhabitedTimeField.getDuration(),
-						radiusField.getNumber(),
-						selection
-				);
+				PruneData pruneData = new PruneData(worldDir, duration, radius, selection, whitelistOnly);
 				DialogErrorHandler errorHandler = new DialogErrorHandler(INSTANCE);
 				new Pruner(pruneData, errorHandler).prune(progressBar);
 				if (errorHandler.wasSuccessful()) {

--- a/src/main/java/net/querz/worldpruner/ui/Window.java
+++ b/src/main/java/net/querz/worldpruner/ui/Window.java
@@ -9,7 +9,10 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import javax.imageio.ImageIO;
 import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
 import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -21,6 +24,9 @@ public final class Window extends JFrame {
 	private static final Logger LOGGER = LogManager.getLogger(Window.class);
 
 	public static Window INSTANCE;
+
+	private JButton prune;
+	private JButton pruneForWhitelist;
 
 	private Window() {
 	}
@@ -53,14 +59,29 @@ public final class Window extends JFrame {
 		JPanel panel = new JPanel();
 		panel.setLayout(new BorderLayout());
 
-		JButton prune = new JButton("Prune");
-		prune.setAlignmentX(Component.CENTER_ALIGNMENT);
+		INSTANCE.prune = new JButton("Prune");
+		INSTANCE.prune.setAlignmentX(Component.CENTER_ALIGNMENT);
+		INSTANCE.pruneForWhitelist = new JButton("Prune for whitelist");
+		INSTANCE.pruneForWhitelist.setAlignmentX(Component.CENTER_ALIGNMENT);
 
 		JPanel options = new JPanel();
 		SpringLayout springLayout = new SpringLayout();
 		options.setLayout(springLayout);
 
-		JLabel worldLabel = new JLabel("World: ");
+		JLabel worldLabel = new JLabel("World: \u24D8");
+		worldLabel.setOpaque(true);
+		addInfoDialog(worldLabel, """
+				<body style="font-family: Sans-Serif; font-size: 12;">
+					<span>A World folder is the folder containing all your world files.</span>
+					<br/>
+					<br/>
+					<span>It always contains a sub-folder <b>region</b>, as well as <b>poi</b> and since Minecraft 1.17, <b>entities</b>.</span>
+					<br/>
+					<br/>
+					<span>For The Nether and The End, select the <b>DIM-1</b> and <b>DIM1</b> folders respectively.</span>
+				</body>
+				""");
+
 		FileTextField worldField = new FileTextField(null, "Open World");
 		worldField.setInvalidTooltip("Not a valid Minecraft world folder");
 		worldField.setFileValidator((s, f) -> {
@@ -78,21 +99,61 @@ public final class Window extends JFrame {
 		options.add(worldLabel);
 		options.add(worldField);
 
-		JLabel inhabitedTimeLabel = new JLabel("InhabitedTime: ");
+		JLabel inhabitedTimeLabel = new JLabel("InhabitedTime: \u24D8");
+		inhabitedTimeLabel.setOpaque(true);
+		addInfoDialog(inhabitedTimeLabel, """
+				<body style="font-family: Sans-Serif; font-size: 12;">
+					<span>The minimum InhabitedTime of a chunk for WorldPruner to <i>not</i> delete it.</span>
+					<br/>
+					<br/>
+					<span><b>Example:</b></span>
+					<br/>
+					<span>1 day 3 hours 5 minutes 30 seconds</span>
+					<br/>
+					<br/>
+					<span>In recent versions of Minecraft, InhabitedTime is the <i>accumulated</i> time</span>
+					<br/>
+					<span>of all players who have spent any time in that chunk.</span>
+				</body>
+				""");
+
 		InhabitedTimeTextField inhabitedTimeField = new InhabitedTimeTextField("5 minutes", 20);
 		inhabitedTimeLabel.setLabelFor(inhabitedTimeField);
 		inhabitedTimeField.setHorizontalAlignment(JTextField.CENTER);
 		options.add(inhabitedTimeLabel);
 		options.add(inhabitedTimeField);
 
-		JLabel radiusLabel = new JLabel("Radius: ");
+		JLabel radiusLabel = new JLabel("Radius: \u24D8");
+		radiusLabel.setOpaque(true);
+		addInfoDialog(radiusLabel, """
+				<body style="font-family: Sans-Serif; font-size: 12;">
+					<span>The radius of additional chunk preserved around matching chunks.</span>
+					<br/>
+					<br/>
+					<span>The maximum allowed radius is <b>128</b>.</span>
+					<br/>
+					<span>The radius does not affect chunks containing structure data</span>
+					<span>but did not match the InhabitedTime condition</span>
+				</body>
+				""");
 		NumberTextField radiusField = new NumberTextField(PruneData.MIN_RADIUS, PruneData.MAX_RADIUS, "0", 20);
 		radiusLabel.setLabelFor(radiusField);
 		radiusField.setHorizontalAlignment(JTextField.CENTER);
 		options.add(radiusLabel);
 		options.add(radiusField);
 
-		JLabel whitelistLabel = new JLabel("Whitelist: ");
+		JLabel whitelistLabel = new JLabel("Whitelist: \u24D8");
+		whitelistLabel.setOpaque(true);
+		addInfoDialog(whitelistLabel, """
+				<body style="font-family: Sans-Serif; font-size: 12;">
+					<span>The whitelist contains chunks and regions that need to be kept in <i>any case</i>.</span>
+					<br/>
+					<br/>
+					<span>Whitelists can be created in MCA Selector by using <b>Selection --> Export selection as .csv</b>.</span>
+					<br/>
+					<span>Custom whitelists can be created by following the format specification <a href="https://github.com/Querz/mcaselector/wiki/Selections#selection-file-format">here</a>.</span>
+				</body>
+				""");
 		FileTextField whitelistField = new FileTextField("csv", "Open Whitelist");
 		whitelistField.setInvalidTooltip("Not a csv file");
 		whitelistField.setFileValidator((s, f) -> s == null || s.isEmpty() || f.isFile() && f.getName().endsWith(".csv"));
@@ -102,6 +163,7 @@ public final class Window extends JFrame {
 
 		Runnable pruneButtonValidator = () -> {
 			prune.setEnabled(worldField.isValueValid() && inhabitedTimeField.isDurationValid() && whitelistField.isValueValid());
+			pruneForWhitelist.setEnabled(worldField.isValueValid() && whitelistField.isValueValid() && !whitelistField.getText().isEmpty());
 		};
 
 		worldField.setOnUpdate(pruneButtonValidator);
@@ -118,6 +180,7 @@ public final class Window extends JFrame {
 		ProgressBar progressBar = new ProgressBar();
 		pruneBox.add(progressBar);
 		pruneBox.add(prune);
+		pruneBox.add(pruneForWhitelist);
 
 		panel.add(pruneBox, BorderLayout.SOUTH);
 
@@ -134,57 +197,37 @@ public final class Window extends JFrame {
 			String csvString = whitelistField.getText();
 			Selection selection;
 			if (csvString != null && !csvString.isEmpty()) {
-				File csv = new File(csvString);
-				try {
-					selection = Selection.parseCSV(csv);
-				} catch (IOException ex) {
-					LOGGER.error("Failed to parse whitelist from {}", csv, ex);
-					JOptionPane.showMessageDialog(INSTANCE, ex.getMessage(), "Invalid Whitelist", JOptionPane.ERROR_MESSAGE);
+				selection = getSelection(csvString);
+				if (selection == null) {
 					return;
 				}
 			} else {
 				selection = new Selection();
 			}
 
-			INSTANCE.setFieldsEnabled(false,
-				worldField,
-				inhabitedTimeField,
-				radiusField,
-				whitelistField,
-				prune);
+			prune(prune, worldField, inhabitedTimeField.getDuration(), radiusField, whitelistField, progressBar, worldDir, selection);
+		});
 
-			new Thread(() -> {
-				try {
-					PruneData pruneData = new PruneData(
-						worldDir,
-						inhabitedTimeField.getDuration(),
-						radiusField.getNumber(),
-						selection
-					);
-					DialogErrorHandler errorHandler = new DialogErrorHandler(INSTANCE);
-					new Pruner(pruneData, errorHandler).prune(progressBar);
-					if (errorHandler.wasSuccessful()) {
-						JOptionPane.showMessageDialog(
-							INSTANCE,
-							"Successfully pruned world",
-							"Success",
-							JOptionPane.INFORMATION_MESSAGE);
-					}
-				} finally {
-					try {
-						SwingUtilities.invokeAndWait(() -> {
-							INSTANCE.setFieldsEnabled(true,
-								worldField,
-								inhabitedTimeField,
-								radiusField,
-								whitelistField,
-								prune);
-						});
-					} catch (InterruptedException | InvocationTargetException ex) {
-						LOGGER.error("Failed to re-enable ui fields", ex);
-					}
-				}
-			}).start();
+		pruneForWhitelist.addActionListener(e -> {
+			// sanity check, in case someone deleted folders and didn't update the world text field
+			worldField.update();
+			whitelistField.update();
+			pruneButtonValidator.run();
+			PruneData.WorldDirectory worldDir = PruneData.WorldDirectory.parseWorldDirectory(new File(worldField.getText()));
+			if (!pruneForWhitelist.isEnabled() || worldDir == null) {
+				return;
+			}
+
+			String csvString = whitelistField.getText();
+			Selection selection;
+			if (csvString != null && !csvString.isEmpty()) {
+				selection = getSelection(csvString);
+				if (selection == null) return;
+			} else {
+				return;
+			}
+
+			prune(prune, worldField, inhabitedTimeField.getDuration(), radiusField, whitelistField, progressBar, worldDir, selection);
 		});
 
 		INSTANCE.getContentPane().add(panel);
@@ -194,6 +237,68 @@ public final class Window extends JFrame {
 		// make sure that the AWT Event Queue thread has this ThreadContext map
 		SwingUtilities.invokeLater(() -> ThreadContext.put("dynamicLogLevel", Main.getLogLevel()));
 		INSTANCE.setVisible(true);
+	}
+
+	private static void prune(
+			JButton prune,
+			FileTextField worldField,
+			long inhabitedTime,
+			NumberTextField radiusField,
+			FileTextField whitelistField,
+			ProgressBar progressBar,
+			PruneData.WorldDirectory worldDir,
+			Selection selection) {
+
+		INSTANCE.setFieldsEnabled(false,
+				worldField,
+				inhabitedTimeField,
+				radiusField,
+				whitelistField,
+				prune);
+
+		new Thread(() -> {
+			try {
+				PruneData pruneData = new PruneData(
+						worldDir,
+						inhabitedTimeField.getDuration(),
+						radiusField.getNumber(),
+						selection
+				);
+				DialogErrorHandler errorHandler = new DialogErrorHandler(INSTANCE);
+				new Pruner(pruneData, errorHandler).prune(progressBar);
+				if (errorHandler.wasSuccessful()) {
+					JOptionPane.showMessageDialog(
+							INSTANCE,
+							"Successfully pruned world",
+							"Success",
+							JOptionPane.INFORMATION_MESSAGE);
+				}
+			} finally {
+				try {
+					SwingUtilities.invokeAndWait(() -> {
+						INSTANCE.setFieldsEnabled(true,
+								worldField,
+								inhabitedTimeField,
+								radiusField,
+								whitelistField,
+								prune);
+					});
+				} catch (InterruptedException | InvocationTargetException ex) {
+					LOGGER.error("Failed to re-enable ui fields", ex);
+				}
+			}
+		}).start();
+	}
+
+	private static Selection getSelection(String csvString) {
+		File csv = new File(csvString);
+		try {
+			return Selection.parseCSV(csv);
+		} catch (IOException ex) {
+			LOGGER.error("Failed to parse whitelist from {}", csv, ex);
+			JOptionPane.showMessageDialog(INSTANCE, ex.getMessage(), "Invalid Whitelist", JOptionPane.ERROR_MESSAGE);
+			return null;
+		}
 	}
 
 	private void setFieldsEnabled(boolean enable, JComponent... components) {
@@ -221,5 +326,28 @@ public final class Window extends JFrame {
 			case 3 -> "Found world sub-directories " + subDirs[0] + ", " + subDirs[1] + " and " + subDirs[2];
 			default -> "Found world sub-directories " + String.join(", ", subDirs);
 		};
+	}
+
+	private static void addInfoDialog(JComponent c, String message) {
+		c.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mousePressed(MouseEvent e) {
+				JEditorPane pane = new JEditorPane();
+				pane.setContentType("text/html");
+				pane.setText(message);
+				pane.addHyperlinkListener(h -> {
+					if (HyperlinkEvent.EventType.ACTIVATED.equals(h.getEventType())) {
+						Desktop desktop = Desktop.getDesktop();
+						try {
+							desktop.browse(h.getURL().toURI());
+						} catch (Exception ignored) {
+						}
+					}
+				});
+				pane.setBackground(c.getBackground());
+				pane.setEditable(false);
+				JOptionPane.showMessageDialog(INSTANCE, pane, "Info", JOptionPane.PLAIN_MESSAGE);
+			}
+		});
 	}
 }

--- a/src/main/resources/log4j2.component.properties
+++ b/src/main/resources/log4j2.component.properties
@@ -1,0 +1,7 @@
+# https://logging.apache.org/log4j/2.x/manual/configuration.html#SystemProperties
+
+# Modern 2.10+
+log4j2.isThreadContextMapInheritable=true
+
+# Legacy for pre-2.10
+isThreadContextMapInheritable=true

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -8,15 +8,22 @@
 			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %p %c: %m%n"/>
 		</Console>
 		<RollingFile name="File" fileName="${logDir}/wp.log" filePattern="${logDir}/wp-%d{yyyyMMdd-HHmmss}-%i.log">
-			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %p %c: %m%n"/>
+			<DynamicThresholdFilter key="dynamicLogLevel" defaultThreshold="INFO" onMatch="ACCEPT" onMismatch="DENY">
+				<KeyValuePair key="TRACE" value="TRACE"/>
+				<KeyValuePair key="DEBUG" value="DEBUG"/>
+				<KeyValuePair key="WARN" value="WARN"/>
+				<KeyValuePair key="ERROR" value="ERROR"/>
+				<KeyValuePair key="FATAL" value="FATAL"/>
+			</DynamicThresholdFilter>
+			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %p %c{1}: %m%n"/>
 			<Policies>
-				<SizeBasedTriggeringPolicy size="1MB"/>
+				<SizeBasedTriggeringPolicy size="50MB"/>
 				<OnStartupTriggeringPolicy/>
 			</Policies>
 		</RollingFile>
 	</Appenders>
 	<Loggers>
-		<Root level="trace">
+		<Root level="ALL">
 			<AppenderRef ref="Console"/>
 			<AppenderRef ref="File"/>
 		</Root>

--- a/src/test/java/net/querz/worldpruner/selection/TestPoint.java
+++ b/src/test/java/net/querz/worldpruner/selection/TestPoint.java
@@ -12,49 +12,49 @@ public class TestPoint {
 		@Test
 		void zero() {
 			Point p = new Point(32, 32);
-			Point p2 = p.normalizeChunkInRegion();
+			Point p2 = p.asRelativeChunk();
 			assertEquals(new Point(0, 0), p2);
 		}
 
 		@Test
 		void positive() {
 			Point p = new Point(63, 63);
-			Point p2 = p.normalizeChunkInRegion();
+			Point p2 = p.asRelativeChunk();
 			assertEquals(new Point(31, 31), p2);
 		}
 
 		@Test
 		void negative() {
 			Point p = new Point(-1, -1);
-			Point p2 = p.normalizeChunkInRegion();
+			Point p2 = p.asRelativeChunk();
 			assertEquals(new Point(31, 31), p2);
 		}
 
 		@Test
 		void negativeLower() {
 			Point p = new Point(-31, -31);
-			Point p2 = p.normalizeChunkInRegion();
+			Point p2 = p.asRelativeChunk();
 			assertEquals(new Point(1, 1), p2);
 		}
 
 		@Test
 		void negativeZero() {
 			Point p = new Point(-32, -32);
-			Point p2 = p.normalizeChunkInRegion();
+			Point p2 = p.asRelativeChunk();
 			assertEquals(new Point(0, 0), p2);
 		}
 
 		@Test
 		void moreNegative() {
 			Point p = new Point(-63, -63);
-			Point p2 = p.normalizeChunkInRegion();
+			Point p2 = p.asRelativeChunk();
 			assertEquals(new Point(1, 1), p2);
 		}
 
 		@Test
 		void moreNegativeZero() {
 			Point p = new Point(-64, -64);
-			Point p2 = p.normalizeChunkInRegion();
+			Point p2 = p.asRelativeChunk();
 			assertEquals(new Point(0, 0), p2);
 		}
 	}
@@ -68,7 +68,7 @@ public class TestPoint {
 
 			Point p = new Point(cx, cz);
 
-			System.out.println(p.getAsRelativeChunk());
+			System.out.println(p.asChunkIndex());
 		}
 	}
 }

--- a/src/test/java/net/querz/worldpruner/selection/TestSelection.java
+++ b/src/test/java/net/querz/worldpruner/selection/TestSelection.java
@@ -1,7 +1,6 @@
 package net.querz.worldpruner.selection;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,7 +12,7 @@ public class TestSelection {
 
 		@Test
 		void noInversion() {
-			Long2ObjectOpenHashMap<ShortOpenHashSet> sel = new Long2ObjectOpenHashMap<>();
+			Long2ObjectOpenHashMap<ChunkSet> sel = new Long2ObjectOpenHashMap<>();
 
 			// complete region
 			sel.put(new Point(0, 0).asLong(), null);
@@ -26,7 +25,7 @@ public class TestSelection {
 
 		@Test
 		void inversion() {
-			Long2ObjectOpenHashMap<ShortOpenHashSet> sel = new Long2ObjectOpenHashMap<>();
+			Long2ObjectOpenHashMap<ChunkSet> sel = new Long2ObjectOpenHashMap<>();
 			sel.put(new Point(0, 0).asLong(), null);
 			Selection s = new Selection(sel, true);
 			assertFalse(s.isChunkSelected(0, 0));
@@ -37,11 +36,11 @@ public class TestSelection {
 
 		@Test
 		void noInversionIndividualChunks() {
-			Long2ObjectOpenHashMap<ShortOpenHashSet> sel = new Long2ObjectOpenHashMap<>();
+			Long2ObjectOpenHashMap<ChunkSet> sel = new Long2ObjectOpenHashMap<>();
 			Selection s = new Selection(sel, false);
-			ShortOpenHashSet c = new ShortOpenHashSet();
-			c.add(new Point(0, 0).getAsRelativeChunk());
-			c.add(new Point(5, 8).getAsRelativeChunk());
+			ChunkSet c = new ChunkSet();
+			c.set(new Point(0, 0).asChunkIndex());
+			c.set(new Point(5, 8).asChunkIndex());
 			sel.put(new Point(0, 0).asLong(), c);
 			assertTrue(s.isChunkSelected(0, 0));
 			assertTrue(s.isChunkSelected(5, 8));
@@ -56,11 +55,11 @@ public class TestSelection {
 
 		@Test
 		void inversionIndividualChunks() {
-			Long2ObjectOpenHashMap<ShortOpenHashSet> sel = new Long2ObjectOpenHashMap<>();
+			Long2ObjectOpenHashMap<ChunkSet> sel = new Long2ObjectOpenHashMap<>();
 			Selection s = new Selection(sel, true);
-			ShortOpenHashSet c = new ShortOpenHashSet();
-			c.add(new Point(0, 0).getAsRelativeChunk());
-			c.add(new Point(5, 8).getAsRelativeChunk());
+			ChunkSet c = new ChunkSet();
+			c.set(new Point(0, 0).asChunkIndex());
+			c.set(new Point(5, 8).asChunkIndex());
 			sel.put(new Point(0, 0).asLong(), c);
 			assertFalse(s.isChunkSelected(0, 0));
 			assertFalse(s.isChunkSelected(5, 8));


### PR DESCRIPTION
- Use custom bit set to store chunks more efficiently in memory for the selection
- Fix EOF when attempting to index chunks from mca files with a size < 8192
- Added --debug/-d parameter to enable DEBUG level for log file
- Logging more info and stats to log file while pruning
- Added info dialogs for all four input fields
- Added `Prune for whitelist` button to prune everything except the whitelist, ignoring InhabitedTime and radius
- Added tooltips for prune buttons
- Added a confirmation dialog for the prune buttons with a warning message